### PR TITLE
Run watchOS tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -45,7 +45,6 @@ jobs:
         -quiet
 
     - name: Test
-      if: ${{ !contains(matrix.DESTINATION, 'watchOS') }} # watchOS Simulator is too slow on GitHub-hosted Runners, expectation-related tests are flaky
       run: >
         xcodebuild test
         -scheme ${{ env.SCHEME }}


### PR DESCRIPTION
Tests flacked on watchOS simulator. Since I've made BlackBox synchronous in https://github.com/dodobrands/BlackBox/pull/44 tests aren't flaky anymore.