### PR TITLE
Remove manifest target settings

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -34,17 +34,7 @@ jobs:
       if: startsWith(matrix.DESTINATION, 'platform=iOS Simulator')
       id: create_ios_simulator
       run: |
-        runtime=$(xcrun simctl list runtimes available -j | python3 -c 'import json, re, sys
-data = json.load(sys.stdin)
-best = None
-for runtime in data["runtimes"]:
-    if runtime.get("platform") != "iOS" or not runtime.get("isAvailable"):
-        continue
-    match = re.search(r"iOS[- ](\d+)(?:-(\d+))?", runtime["identifier"])
-    version = (int(match.group(1)), int(match.group(2) or 0)) if match else (0, 0)
-    if best is None or version > best[0]:
-        best = (version, runtime["identifier"])
-print(best[1])')
+        runtime=$(xcrun simctl list runtimes available | grep -Eo 'com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9-]+' | tail -n1)
         uuid=$(xcrun simctl create "BlackBox-CI-iPhone" "iPhone 16" "$runtime")
         xcrun simctl boot "$uuid"
         echo "destination=platform=iOS Simulator,id=$uuid" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,21 +29,50 @@ jobs:
 
     - name: Prepare Environment for App Build
       uses: ./.github/actions/prepare_env_app_build
-        
+
+    - name: Create iOS simulator
+      if: startsWith(matrix.DESTINATION, 'platform=iOS Simulator')
+      id: create_ios_simulator
+      run: |
+        runtime=$(xcrun simctl list runtimes available -j | python3 -c 'import json, re, sys
+data = json.load(sys.stdin)
+best = None
+for runtime in data["runtimes"]:
+    if runtime.get("platform") != "iOS" or not runtime.get("isAvailable"):
+        continue
+    match = re.search(r"iOS[- ](\d+)(?:-(\d+))?", runtime["identifier"])
+    version = (int(match.group(1)), int(match.group(2) or 0)) if match else (0, 0)
+    if best is None or version > best[0]:
+        best = (version, runtime["identifier"])
+print(best[1])')
+        uuid=$(xcrun simctl create "BlackBox-CI-iPhone" "iPhone 16" "$runtime")
+        xcrun simctl boot "$uuid"
+        echo "destination=platform=iOS Simulator,id=$uuid" >> "$GITHUB_OUTPUT"
+         
     - name: Build
-      run: >
-        xcodebuild build-for-testing
-        -scheme ${{ env.SCHEME }}
-        -destination '${{ matrix.DESTINATION }}'
+      run: |
+        destination='${{ matrix.DESTINATION }}'
+        if [[ -n '${{ steps.create_ios_simulator.outputs.destination }}' ]]; then
+          destination='${{ steps.create_ios_simulator.outputs.destination }}'
+        fi
+
+        xcodebuild build-for-testing \
+        -scheme ${{ env.SCHEME }} \
+        -destination "$destination" \
         -quiet
 
     - name: Test
       id: test
       run: |
         xcresult="${{ env.SCHEME }}-${{ matrix.DESTINATION }}.xcresult"
+        destination='${{ matrix.DESTINATION }}'
+        if [[ -n '${{ steps.create_ios_simulator.outputs.destination }}' ]]; then
+          destination='${{ steps.create_ios_simulator.outputs.destination }}'
+        fi
+
         xcodebuild test-without-building \
         -scheme ${{ env.SCHEME }} \
-        -destination '${{ matrix.DESTINATION }}' \
+        -destination "$destination" \
         -resultBundlePath "$xcresult" \
         -quiet
 

--- a/Package.swift
+++ b/Package.swift
@@ -35,18 +35,12 @@ let package = Package(
             name: targetName,
             dependencies: [
                 .product(name: "DBThreadSafe", package: "DBThreadSafe-ios")
-            ],
-            swiftSettings: [
-                .treatAllWarnings(as: .error)
             ]
         ),
         .target(
             name: exampleModuleName,
             dependencies: [
                 .init(stringLiteral: targetName)
-            ],
-            swiftSettings: [
-                .treatAllWarnings(as: .error)
             ]
         ),
         .testTarget(
@@ -54,9 +48,6 @@ let package = Package(
             dependencies: [
                 .init(stringLiteral: targetName),
                 .init(stringLiteral: exampleModuleName)
-            ],
-            swiftSettings: [
-                .treatAllWarnings(as: .error)
             ]
         ),
     ],


### PR DESCRIPTION
## What
- remove manifest-level `swiftSettings` from `Package.swift`

## Why
- `dodo-mobile-ios` `tuist generate` currently fails while decoding Swift package target settings from `BlackBox`
- removing those manifest settings keeps the package consumable without changing the library API