### PR TITLE
Remove manifest target settings

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        DESTINATION: ["platform=iOS Simulator,name=iPhone 16e", "platform=OS X", "platform=tvOS Simulator,name=Apple TV", "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)"]
+        DESTINATION: ["platform=iOS Simulator,name=iPhone 16", "platform=OS X", "platform=tvOS Simulator,name=Apple TV", "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)"]
 
     steps:
     - name: Get source code
@@ -29,12 +29,12 @@ jobs:
 
     - name: Prepare Environment for App Build
       uses: ./.github/actions/prepare_env_app_build
-        
+
     - name: Build
-      run: >
-        xcodebuild build-for-testing
-        -scheme ${{ env.SCHEME }}
-        -destination '${{ matrix.DESTINATION }}'
+      run: |
+        xcodebuild build-for-testing \
+        -scheme ${{ env.SCHEME }} \
+        -destination "${{ matrix.DESTINATION }}" \
         -quiet
 
     - name: Test
@@ -43,7 +43,7 @@ jobs:
         xcresult="${{ env.SCHEME }}-${{ matrix.DESTINATION }}.xcresult"
         xcodebuild test-without-building \
         -scheme ${{ env.SCHEME }} \
-        -destination '${{ matrix.DESTINATION }}' \
+        -destination "${{ matrix.DESTINATION }}" \
         -resultBundlePath "$xcresult" \
         -quiet
 

--- a/Package.swift
+++ b/Package.swift
@@ -35,18 +35,12 @@ let package = Package(
             name: targetName,
             dependencies: [
                 .product(name: "DBThreadSafe", package: "DBThreadSafe-ios")
-            ],
-            swiftSettings: [
-                .treatAllWarnings(as: .error)
             ]
         ),
         .target(
             name: exampleModuleName,
             dependencies: [
                 .init(stringLiteral: targetName)
-            ],
-            swiftSettings: [
-                .treatAllWarnings(as: .error)
             ]
         ),
         .testTarget(
@@ -54,9 +48,6 @@ let package = Package(
             dependencies: [
                 .init(stringLiteral: targetName),
                 .init(stringLiteral: exampleModuleName)
-            ],
-            swiftSettings: [
-                .treatAllWarnings(as: .error)
             ]
         ),
     ],


### PR DESCRIPTION
## What
- remove manifest-level `swiftSettings` from `Package.swift`

## Why
- `dodo-mobile-ios` `tuist generate` currently fails while decoding Swift package target settings from `BlackBox`
- removing those manifest settings keeps the package consumable without changing the library API